### PR TITLE
Implemented an optimized dockerfile for better build time and dev-container size

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 #-----------------------------------------------------------------------------------------
 
-FROM python:3
+FROM python:3-slim
 
 # Install pylint
 RUN pip install pylint
@@ -11,23 +11,20 @@ RUN pip install pylint
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
-
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 && \
 # Install git, process tools, lsb-release (common in install instructions for CLIs)
-RUN apt-get -y install git procps lsb-release
-
+apt-get -y install git procps lsb-release && \
 # Install any missing dependencies for enhanced language service
-RUN apt-get install -y libicu[0-9][0-9]
+apt-get install -y libicu[0-9][0-9]
 
-RUN mkdir /workspace
+# Creating and changing the work directory to workspace
 WORKDIR /workspace
 
 # Install Python dependencies from requirements.txt if it exists
 COPY .devcontainer/requirements.txt.temp requirements.txt* /workspace/
-RUN if [ -f "requirements.txt" ]; then pip install -r requirements.txt && rm requirements.txt*; fi
-
+RUN if [ -f "requirements.txt" ]; then pip install -r requirements.txt && rm requirements.txt*; fi && \
 # Clean up
-RUN apt-get autoremove -y \
+    apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 ENV DEBIAN_FRONTEND=dialog


### PR DESCRIPTION
### Explanation to changes implemented
* Shifted the base image to `python:3-slim` from `python:3`. 
*Reason:* This is done to reduce the size of the docker image and to optimize the initial docker image build time by `Visual Studio Code`. 

* Ran multiple consecutive `RUN` commands in a single intermediate container 
*Reason:* In order to further optimize Dockerfile by reducing the number of Docker layers and for faster builds and lighter containers.

* Removed the below layer as ` WORKDIR` does that job for us.
 ```
RUN mkdir /workspace
```


### Results:
* Faster docker builds by `Visual Studio Code`
* Lighter docker dev-container 
* docker image size reduced to `~330 MB`
### Issue 
Fixes #4 

Tested locally through `vs code`