### PR TITLE
Setting the docker build context with build.context doesn't work

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
 	"name": "Python 3 Sample",
+	"context": "..",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"context": "..",
 		// Update 'VARIANT' to pick a Python version. Rebuild the container 
 		// if it already exists to update. Available variants: 3, 3.6, 3.7, 3.8 
 		"args": { "VARIANT": "3.7" }


### PR DESCRIPTION
I am using Docker Desktop for Windows v 2.2.0.5 on Windows 10. In my case, VSCode was not able to set the container build context correctly by reading the `build.context` property. I fixed the issue by setting the `context` property as mentioned in the schema here: https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference.