### PR TITLE
Update ports and use Pylance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,8 +41,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [9000],
 
-	// Use 'portsAttributes' to set default properties for specific forwarded ports.
-	// You can use a port number (i.e. 3000), range of numbers, or a regex to match the running process.
+	// Use 'portsAttributes' to set default properties for specific forwarded ports. More info: https://code.visualstudio.com/docs/remote/devcontainerjson-reference.
 	"portsAttributes": {
 		"9000": {
 			"label": "Hello Remote World",
@@ -58,6 +57,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pip3 install -r requirements.txt",
 
-	// Comment out to connect as root instead.
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/usr/local/bin/python",
+		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
@@ -33,22 +34,29 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"ms-python.vscode-pylance"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [9000],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install -r requirements.txt",
-
 	// Use 'portsAttributes' to set default properties for specific forwarded ports.
+	// You can use a port number (i.e. 3000), range of numbers, or a regex to match the running process.
 	"portsAttributes": {
 		"9000": {
 			"label": "Hello Remote World",
 			"onAutoForward": "notify"
 		}
 	},
+
+	// Use 'otherPortsAttributes' to configure any ports that aren't configured using 'portsAttributes'.
+	// "otherPortsAttributes": {
+	// 		"onAutoForward": "silent"
+	// },
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip3 install -r requirements.txt",
 
 	// Comment out to connect as root instead.
 	"remoteUser": "vscode"

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Some things to try:
 
    You may want to make changes to your container, such as installing a different version of a software or forwarding a new port. You'll rebuild your container for your changes to take effect. 
 
-   **Forward a port statically:** As an example change, let's forward a port statically in the `.devcontainer/devcontainer.json` file. 
+   **Open browser automatically:** As an example change, let's update the `portsAttributes` in the `.devcontainer/devcontainer.json` file to open a browser when our port is automatically forwarded.
 
    > **Note:** Remote-Containers and Codespaces also take care of dynamic port forwarding, but there may be instances in which we want to statically declare a forwarded port. 
    
    - Open the `.devcontainer/devcontainer.json` file.
-   - Uncomment the `forwardedPorts` attribute and adjust the port number as needed.
+   - Modify the `"onAutoForward"` attribute in your `portsAttributes` to `"openBrowser"`.
    - Press <kbd>F1</kbd> and select the **Remote-Containers: Rebuild Container** or **Codespaces: Rebuild Container** command so the modifications are picked up.  
 
 ### More samples


### PR DESCRIPTION
Update ports attributes following practices from the Node PR: https://github.com/microsoft/vscode-remote-try-node/pull/23.

Main difference is instead of using a regex (I couldn't find a great regex for this app):

I kept "9000" but updated the in-line comment to describe the ability to use a range or regex.

Since we recently updated the vscode-dev-containers repo definitions to use Pylance, updated this sample to use Pylance as well (install language server and extension). 

*I was initially just going to merge in changes to the other remote-samples following the format from the Node PR, but since it seems like not all samples may be as suited to using a regex, wanted to get another set of eyes on this PR (also since I'm updating to use Pylance).