### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Some things to try:
     - Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> to open a terminal window.
     - Type `python -m flask run --port 9000 --no-debugger --no-reload` to run the app.
          - The terminal will say your app is `Running on http://127.0.0.1:9000/`. Click on the link in the terminal to view your app running in the browser.
-    - Notice that the Python extension is already installed in the container since the `.devcontainer/devcontainer.json` lists `"ms-python.python"` as an extension to install automatically when the container is created.
     
       > **Tip:** If you use this container outside of VS Code via `docker run` with `-p 9000`, you may need to append `--host 0.0.0.0` to the command above. The `-p` option "publishes" the port rather than forwarding it. It therefore will not work if the application only listens to localhost. The `forwardPorts` property in `devcontainer.json` does not have this limitation, but you can use `appPort` property instead if you want to mirror the `docker run` behavior.
 


### PR DESCRIPTION
`.devcontainer/devcontainer.json` does not list `"ms-python.python"` as an extension in this repo.

The existence of the Python extension is already correctly explained in **1. Edit**.