### PR TITLE
feat(docker): add Docker and Docker Compose support with documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use Python 3.12 slim image for smaller size
+FROM python:3.12-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port 9000
+EXPOSE 9000
+
+# Run the Flask application
+CMD ["python", "-m", "flask", "run", "--host=0.0.0.0", "--port=9000"]

--- a/README.md
+++ b/README.md
@@ -88,9 +88,72 @@ Some things to try:
    - Click OK
    - Press <kbd>F1</kbd> and select the **Dev Containers: Rebuild Container** or **Codespaces: Rebuild Container** command so the modifications are picked up.
 
-### More samples
+## Running with Docker
 
-- [Tweeter App - Python and Django](https://github.com/Microsoft/python-sample-tweeterapp)
+For users who prefer standard Docker over Dev Containers, this project now includes Docker support.
+
+### Prerequisites
+- [Docker](https://docs.docker.com/get-docker/) installed on your system
+- [Docker Compose](https://docs.docker.com/compose/install/) (included with Docker Desktop)
+
+### Quick Start with Docker Compose
+
+```bash
+# Build and start the application
+docker compose up --build
+
+# Stop the application
+docker compose down
+```
+
+### Alternative: Using Docker directly
+
+```bash
+# Build the image
+docker build -t vscode-remote-try-python .
+
+# Run the container
+docker run --rm -p 9000:9000 vscode-remote-try-python
+```
+
+### Docker Configuration
+
+**Base Image**: `python:3.12-slim` - Lightweight Python runtime
+
+**Services**:
+- `web`: Flask application server
+
+**Ports**:
+- `9000:9000` - Flask app accessible at http://localhost:9000
+
+### Troubleshooting Docker
+
+**Port already in use**:
+```bash
+# Change the host port (left side) in docker-compose.yml
+ports:
+  - "9001:9000"  # Now accessible at http://localhost:9001
+```
+
+**Rebuild after dependency changes**:
+```bash
+docker compose build --no-cache
+docker compose up
+```
+
+**Permission denied (Linux/macOS)**:
+```bash
+# Add user to docker group
+sudo usermod -aG docker $USER
+# Then log out and back in
+```
+
+**View container logs**:
+```bash
+docker compose logs -f
+```
+
+### More samples
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    ports:
+      - "9000:9000"
+    environment:
+      - FLASK_ENV=development
+    volumes:
+      - .:/app
+    command: python -m flask run --host=0.0.0.0 --port=9000 --reload


### PR DESCRIPTION
### What I changed
- Added Dockerfile with Python 3.12-slim base image
- Added docker-compose.yml for development workflow
- Added Docker documentation to README with troubleshooting

### Why
Project only had Dev Container support. This adds standard Docker support for broader accessibility.

### How to test
1. `docker compose up --build`
2. Open http://localhost:9000